### PR TITLE
Fix o365-connect-exo.ps1

### DIFF
--- a/o365-connect-exo.ps1
+++ b/o365-connect-exo.ps1
@@ -5,17 +5,12 @@ param(
 )
 <# CIAOPS
 Script provided as is. Use at own risk. No guarantees or warranty provided.
-
 Description - Log to Exchange Online using the V2 module
 Reference - https://docs.microsoft.com/en-us/powershell/exchange/exchange-online/exchange-online-powershell-v2/exchange-online-powershell-v2?view=exchange-ps
-
 Source - https://github.com/directorcia/Office365/blob/master/o365-connect-exo.ps1
-
 Prerequisites = 1
 1. Ensure Exchange Online module is installed
-
 More scripts available by joining http://www.ciaopspatron.com
-
 #>
 
 ## Variables
@@ -26,6 +21,9 @@ $warningmessagecolor = "yellow"
 
 ## If you have running scripts that don't have a certificate, run this command once to disable that level of security
 ##  set-executionpolicy -executionpolicy bypass -scope currentuser -force
+
+## Enforce higher version of TLS
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 
 Clear-Host
 
@@ -46,7 +44,7 @@ else {
         do {
             $response = read-host -Prompt "`nDo you wish to install the Exchange Online PowerShell module (Y/N)?"
         } until (-not [string]::isnullorempty($response))
-        if ($result -eq 'Y' -or $result -eq 'y') {
+        if ($response -eq 'Y' -or $response -eq 'y') {
             write-host -foregroundcolor $processmessagecolor "Installing PowerShellGet module - Administration escalation required"
             Start-Process powershell -Verb runAs -ArgumentList "Install-Module PowershellGet -Force" -wait -WindowStyle Hidden       
             write-host -foregroundcolor $processmessagecolor "Installing Exchange Online PowerShell module - Administration escalation required"

--- a/o365-connect-exo.ps1
+++ b/o365-connect-exo.ps1
@@ -22,10 +22,10 @@ $warningmessagecolor = "yellow"
 ## If you have running scripts that don't have a certificate, run this command once to disable that level of security
 ##  set-executionpolicy -executionpolicy bypass -scope currentuser -force
 
+Clear-Host
+
 ## Enforce higher version of TLS
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-
-Clear-Host
 
 if ($debug) {
     write-host "Script activity logged at ..\o365-connect-exo.txt"


### PR DESCRIPTION
- Fixed an issue with the read-host prompt checking the wrong variable for the answer.
- Enforced TLS1.2 which prevented some clients from installing the ExchangeOnlineManagement module
