### PR TITLE
Update win10-asr-get.ps1

### DIFF
--- a/win10-asr-get.ps1
+++ b/win10-asr-get.ps1
@@ -23,7 +23,7 @@ $systemmessagecolor = "cyan"
 $processmessagecolor = "green"
 $errormessagecolor="red"
 $warningmessagecolor = "yellow"
-$warningmessagecolor = "cyan"
+$auditmessagecolor = "cyan"
 
 Clear-Host
 write-host -foregroundcolor $systemmessagecolor "Script started`n"


### PR DESCRIPTION
Fix for undefined `$auditmessagecolor`.  
Rules set to audit will be displayed in cyan.

resolves #21 